### PR TITLE
Improve syntax fixer path handling

### DIFF
--- a/fix_all_syntax_errors.py
+++ b/fix_all_syntax_errors.py
@@ -124,7 +124,8 @@ def process_file(filepath):
 
 def main():
     """Main function to process all GDScript files."""
-    project_root = Path("/Users/gagelaporta/Desktop/Neuro/NeuroVis-Repo")
+    # Use current working directory as project root
+    project_root = Path.cwd()
 
     # Files with known issues
     problem_files = [


### PR DESCRIPTION
## Summary
- allow `fix_all_syntax_errors.py` to run from any location by using `Path.cwd()`

## Testing
- `python fix_all_syntax_errors.py >/tmp/fix_syntax.log && tail -n 20 /tmp/fix_syntax.log`
- `python -m gdtoolkit.linter . >/tmp/gdlint.log && tail -n 20 /tmp/gdlint.log`

------
https://chatgpt.com/codex/tasks/task_e_68476acade88832eb22a10427d55dfff